### PR TITLE
remove tsconfig from vercelignore

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,3 +1,2 @@
 package-lock.json
 README.md
-tsconfig.json


### PR DESCRIPTION
related issue: https://vercel.community/t/hono-node-runtime-wont-deploy-on-vercel/2612

In order for Vercel to deploy ESM projects with `"type": "module"` in the package.json, it must have the tsconfig correctly set to ESNext

```json
{
  "compilerOptions": {
    "module": "ESNext",
    "moduleResolution": "node"
  }
}
```

This starter currently ignores the tsconfig so all deploys will succeed but fail at runtime with `ReferenceError: exports is not defined in ES module scope` unless you build locally and deploy the pre-built files

